### PR TITLE
Added support for custom destination folder and changed default folder to use workdir/storehouse

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,4 @@
 """Settings for the kytos/storehouse NApp."""
 
-# If you want to use a custom folder other than kytos workdir.
-CUSTOM_DESTINATION_FOLDER = ""
+# Path to serialize the objects, this is relative to a venv, if a venv exists.
+CUSTOM_DESTINATION_PATH = "/var/tmp/kytos/storehouse"

--- a/settings.py
+++ b/settings.py
@@ -1,1 +1,4 @@
 """Settings for the kytos/storehouse NApp."""
+
+# If you want to use a custom folder other than kytos workdir.
+CUSTOM_DESTINATION_FOLDER = ""


### PR DESCRIPTION
Hi team, storehouse was prototyped with a destination directory under /tmp, which doesn't persist after a reboot on the server running kytos. This PR allows that by default a directory 'storehouse' will be used under kytos workdir aka '/var/lib/kytos/storehouse'. Alternatively, the user can specify a CUSTOM_DESTINATION_FOLDER in the settings.py if he wishes to store this folder somewhere else.

## Tests:

I've tested manually with these configurations:

### `settings.CUSTOM_DESTINATION_FOLDER = ""`

As you can see, it's under options.workdir/storehouse:

```
2018-05-17 06:53:12,310 - DEBUG [kytos/storehouse:38] (Thread-13) FileSystem destination_folder: /home/arcanjo/repos/kytos/.direnv/python-3.6.5/var/lib/kytos/storehouse
```

Creating and getting a new EVC:

```
❯ curl -X POST --data-binary @evc.json -H "Content-type: application/json" http://localhost:8181/api/kytos/mef_eline/v2/evc/ -v
{"circuit_id":"7487fd2c808648d09903d19e84c58403"}
* Closing connection 0

~/repos/napps/kytos/mef_eline pr/23*
❯ curl -X GET http://localhost:8181/api/kytos/mef_eline/v2/evc/
{"7487fd2c808648d09903d19e84c58403":{"active":false,"backup_links":[],"backup_path":[],"bandwidth":0,"creation_time":"2018-05-17T09:55:57","current_path":[],"dynamic_backup_path":false,"enabled":false,"end_da
te":null,"id":"7487fd2c808648d09903d19e84c58403","name":"s2-s3","owner":null,"primary_links":[],"primary_path":[],"priority":0,"request_time":"2018-05-17T09:55:57","start_date":"2018-05-17T09:55:57","uni_a":{
"interface_id":"00:00:00:00:00:00:00:03:1","tag":{"tag_type":1,"value":80}},"uni_z":{"interface_id":"00:00:00:00:00:00:00:02:1","tag":{"tag_type":1,"value":80}}}}
```

Pickled file:

```
~/repos/kytos/.direnv/python-3.6.5/var/lib/kytos/storehouse
❯ ls kytos.mef_eline.circuits
0e3b9fb44426464a8e6505f4198e6b81
```

### `settings.CUSTOM_DESTINATION_FOLDER = "/tmp/kytos/storehouse"`

Logs:

```
2018-05-17 07:01:26,399 - DEBUG [kytos/storehouse:38] (Thread-15) FileSystem destination_folder: /tmp/kytos/storehouse
2018-05-17 07:01:26,399 - INFO [kytos/mef_eline:302] (Thread-14) Box b4639969b1c3469c8253158c560f2101 was created in kytos.mef_eline.circuits.
```

Creating a new EVC:

```
❯ curl -X GET http://localhost:8181/api/kytos/mef_eline/v2/evc/
{}

~/repos/napps/kytos/mef_eline pr/23*
❯ curl -X POST --data-binary @evc.json -H "Content-type: application/json" http://localhost:8181/api/kytos/mef_eline/v2/evc/
{"circuit_id":"0e9915e352894ed4a64c22d67818db63"}

```

Pickled file:

```
❯ ls /tmp/kytos/storehouse/kytos.mef_eline.circuits
b4639969b1c3469c8253158c560f2101
```

