### PR TITLE
Fix Linter issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ class Linter(SimpleCommand):
             print('No linter error found.')
         except CalledProcessError:
             print('Linter check failed. Fix the error(s) above and try again.')
-            exit(-1)
+            sys.exit(-1)
 
 
 class CITest(SimpleCommand):


### PR DESCRIPTION
Scrutinizer is reporting a linter error. This commit solves an issue about an "exit(-1)" statement in setup.py