### PR TITLE
Add filter to log messages from the filelock package, avoiding information overload

### DIFF
--- a/backends/fs.py
+++ b/backends/fs.py
@@ -3,6 +3,7 @@
 Save and load data from the local filesystem.
 """
 
+import logging
 import os
 import pickle
 from pathlib import Path
@@ -31,6 +32,7 @@ class FileSystem(StoreBase):
 
     def __init__(self):
         """Initialize directory paths for the FileSystem backend."""
+        logging.getLogger("filelock").setLevel(logging.WARNING)
         self.destination_path = getattr(settings,
                                         'CUSTOM_DESTINATION_PATH',
                                         '/var/tmp/kytos/storehouse')


### PR DESCRIPTION
Today, all log messages from the `filelock` package are shown on the kytos
console, generating a lot of information for the user. Now, only log messages
as a warning or above are shown.

A lot the logs reported in issue #54 are generated by `filelock` package. 

Fix #54 

Main Changes:

-  Filtering log messages from the ` filelock` package.

