### PR TITLE
Remove deprecated `name` parameter

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ pylint==2.4.4             # via yala
 pytest==5.4.1             # via pytest
 pyparsing==2.4.6          # via packaging
 pytest==5.4.1             # via -r dev.in
-six==1.14.0               # via astroid, packaging, pip-tools, tox, virtualenv
+six==1.15.0               # via astroid, packaging, pip-tools, tox, virtualenv
 toml==0.10.0              # via tox
 tox==3.15.0               # via -r dev.in
 typed-ast==1.4.1          # via astroid
@@ -36,7 +36,7 @@ virtualenv==20.0.20       # via tox
 wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid
 yala==2.2.1               # via -r dev.in
-zipp==3.1.0               # via importlib-metadata
+zipp==3.3.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tests/unit/test_box.py
+++ b/tests/unit/test_box.py
@@ -17,17 +17,12 @@ class TestBox(TestCase):
         box_str = '%s.%s' % (self.box.namespace, self.box.box_id)
         self.assertEqual(str(self.box), box_str)
 
-    def test_name_property(self):
-        """Test name property."""
-        self.assertEqual(self.box.name, 'box')
-
     def test_from_json(self):
         """Test from_json method."""
-        data = '{"data": "a", "namespace": "b", "name": "c"}'
+        data = '{"data": "a", "namespace": "b"}'
         from_json_box = self.box.from_json(data)
         self.assertEqual(from_json_box.data, 'a')
         self.assertEqual(from_json_box.namespace, 'b')
-        self.assertEqual(from_json_box.name, 'c')
 
     def test_to_dict(self):
         """Test to_dict method."""
@@ -36,8 +31,7 @@ class TestBox(TestCase):
             "namespace": self.box.namespace,
             "owner": self.box.owner,
             "created_at": self.box.created_at,
-            "id": self.box.box_id,
-            "name": self.box.name
+            "id": self.box.box_id
         }
         dict_data = self.box.to_dict()
         self.assertEqual(dict_data, expected_data)
@@ -49,8 +43,7 @@ class TestBox(TestCase):
             "namespace": self.box.namespace,
             "owner": self.box.owner,
             "created_at": self.box.created_at,
-            "id": self.box.box_id,
-            "name": self.box.name
+            "id": self.box.box_id
         }
         expected_data = json.dumps(data, indent=4)
         json_data = self.box.to_json()
@@ -59,7 +52,6 @@ class TestBox(TestCase):
     def test_metadata_from_box(self):
         """Test metadata_from_box method."""
         expected_metadata = {"box_id": self.box.box_id,
-                             "name": self.box.name,
                              "owner": self.box.owner,
                              "created_at": self.box.created_at}
         metadata = metadata_from_box(self.box)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -39,7 +39,7 @@ class TestMain(TestCase):
 
     def test_create_cache(self):
         """Test create_cache method."""
-        box = Box('any', 'namespace', 'ABC', '123')
+        box = Box('any', 'namespace', '123')
         self.napp.backend.list_namespaces.return_value = ['namespace']
         self.napp.backend.list.return_value = ['123']
         self.napp.backend.retrieve.return_value = box
@@ -48,7 +48,6 @@ class TestMain(TestCase):
 
         box_metadata = self.napp.metadata_cache['namespace'][0]
         self.assertEqual(box_metadata['box_id'], box.box_id)
-        self.assertEqual(box_metadata['name'], box.name)
         self.assertEqual(box_metadata['owner'], box.owner)
         self.assertEqual(box_metadata['created_at'], box.created_at)
 
@@ -58,20 +57,13 @@ class TestMain(TestCase):
         self.napp.delete_metadata_from_cache('namespace', box_id='1')
         self.assertEqual(self.napp.metadata_cache, {'namespace': []})
 
-    def test_delete_metadata_from_cache_by_name(self):
-        """Test delete_metadata_from_cache method using name."""
-        self.napp.metadata_cache = {'namespace': [{'name': 'n'}]}
-        self.napp.delete_metadata_from_cache('namespace', name='n')
-        self.assertEqual(self.napp.metadata_cache, {'namespace': []})
-
     def test_add_metadata_to_cache(self):
         """Test add_metadata_to_cache method."""
-        box = Box('any', 'namespace', 'ABC', '123')
+        box = Box('any', 'namespace', '123')
         self.napp.add_metadata_to_cache(box)
 
         box_metadata = self.napp.metadata_cache['namespace'][0]
         self.assertEqual(box_metadata['box_id'], box.box_id)
-        self.assertEqual(box_metadata['name'], box.name)
         self.assertEqual(box_metadata['owner'], box.owner)
         self.assertEqual(box_metadata['created_at'], box.created_at)
 
@@ -92,11 +84,10 @@ class TestMain(TestCase):
         (mock_box, mock_add_metadata_to_cache) = args
         box = MagicMock()
         box.box_id = '123'
-        box.name = 'ABC'
         mock_box.return_value = box
 
         api = get_test_client(self.napp.controller, self.napp)
-        url = "%s/v1/namespace/123" % self.API_URL
+        url = "%s/v1/123" % self.API_URL
         response = api.open(url, method='POST', json={'data': '123'})
 
         mock_add_metadata_to_cache.assert_called_with(box)
@@ -106,7 +97,7 @@ class TestMain(TestCase):
     def test_rest_create_400(self, *args):
         """Test rest_create method to HTTP 400 response."""
         api = get_test_client(self.napp.controller, self.napp)
-        url = "%s/v1/namespace/123" % self.API_URL
+        url = "%s/v1/123" % self.API_URL
         response = api.open(url, method='POST')
 
         self.assertEqual(response.status_code, 400)
@@ -118,7 +109,6 @@ class TestMain(TestCase):
         (mock_box, mock_add_metadata_to_cache) = args
         box = MagicMock()
         box.box_id = '123'
-        box.name = 'ABC'
         mock_box.return_value = box
 
         api = get_test_client(self.napp.controller, self.napp)


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Fix #64 

### :bookmark_tabs: Description of the Change

This commit removes deprecated `name` parameter from `storehouse` box.

### :computer: Verification Process

- Running unit tests.
- Manually tested in an environment with NApps  `of_core`, `flow_manager`, `of_lldp`, `storehouse` and `topology`.
### :page_facing_up: Release Notes

- Remove deprecated `name` parameter from box.
